### PR TITLE
Add unit support for the export

### DIFF
--- a/curve_to_svg.py
+++ b/curve_to_svg.py
@@ -168,7 +168,7 @@ class DATA_OT_CurveExportSVG(bpy.types.Operator):
         box = [round(x * scale, precision) for x in box]
         svg.set('viewBox', ' '.join(str(x) for x in (box[0], -box[3], box[2] - box[0], box[3] - box[1])))
         
-                my_width = box[2] - box[0]
+        my_width = box[2] - box[0]
         my_height = box[3] - box[1]
         
         unit = bpy.data.scenes["Scene"].unit_settings.length_unit

--- a/curve_to_svg.py
+++ b/curve_to_svg.py
@@ -167,6 +167,27 @@ class DATA_OT_CurveExportSVG(bpy.types.Operator):
 
         box = [round(x * scale, precision) for x in box]
         svg.set('viewBox', ' '.join(str(x) for x in (box[0], -box[3], box[2] - box[0], box[3] - box[1])))
+        
+                my_width = box[2] - box[0]
+        my_height = box[3] - box[1]
+        
+        unit = bpy.data.scenes["Scene"].unit_settings.length_unit
+        
+        if unit == "METERS":
+            unit = "m"
+        elif unit == "KILOMETERS":
+            unit = "km"
+        elif unit == "CENTIMETERS":
+            unit = "cm"
+        elif unit == "MILLIMETERS":
+            unit = "mm"
+        elif unit == "MICROMETERS":
+            unit = "µm"
+        else:
+            unit =  ""
+        
+        svg.set('width', str(my_width) + unit)
+        svg.set('height', str(my_height) + unit)
 
         if scene.export_svg_minify:
             result = "<?xml version=\"1.0\" ?>" + ElementTree.tostring(svg, 'unicode')


### PR DESCRIPTION
For this it uses the width and height attibutes of the svg file. The unit comes from the blender scene settings (lenght). Currently, it is optimised for the metric system (because, let's face it, all other systems are inferior).
